### PR TITLE
Optional to not init our features

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1320,7 +1320,7 @@ export class SqlOpsDataClient extends LanguageClient {
 
 	private registerSqlopsFeatures(features: Array<ISqlopsFeature>) {
 		features.map(f => {
-			new f(this);
+			this.registerFeature(new f(this));
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,9 +21,14 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 	return target[key];
 }
 
-export interface LanguageClientOptions extends VSLanguageClientOptions {
+export interface ISqlopsFeature {
+	new (client: SqlOpsDataClient);
+}
+
+export interface ClientOptions extends VSLanguageClientOptions {
 	providerId: string;
 	serverConnectionMetadata: any;
+	features?: Array<ISqlopsFeature>;
 }
 
 /**
@@ -83,7 +88,7 @@ export abstract class SqlOpsFeature<T> implements DynamicFeature<T> {
 	}
 }
 
-class CapabilitiesFeature extends SqlOpsFeature<undefined> {
+export class CapabilitiesFeature extends SqlOpsFeature<undefined> {
 
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.CapabiltiesDiscoveryRequest.type
@@ -124,7 +129,7 @@ class CapabilitiesFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class ConnectionFeature extends SqlOpsFeature<undefined> {
+export class ConnectionFeature extends SqlOpsFeature<undefined> {
 
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.ConnectionRequest.type,
@@ -264,7 +269,7 @@ class ConnectionFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class QueryFeature extends SqlOpsFeature<undefined> {
+export class QueryFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.QueryExecuteRequest.type,
 		protocol.QueryCancelRequest.type,
@@ -581,7 +586,7 @@ class QueryFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class MetadataFeature extends SqlOpsFeature<undefined> {
+export class MetadataFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.MetadataQueryRequest.type,
 		protocol.ListDatabasesRequest.type,
@@ -661,7 +666,7 @@ class MetadataFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class AdminServicesFeature extends SqlOpsFeature<undefined> {
+export class AdminServicesFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.CreateDatabaseRequest.type,
 		protocol.DefaultDatabaseInfoRequest.type,
@@ -741,7 +746,7 @@ class AdminServicesFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class BackupFeature extends SqlOpsFeature<undefined> {
+export class BackupFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.BackupRequest.type,
 		protocol.BackupConfigInfoRequest.type
@@ -795,7 +800,7 @@ class BackupFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class RestoreFeature extends SqlOpsFeature<undefined> {
+export class RestoreFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.RestorePlanRequest.type,
 		protocol.RestoreRequest.type,
@@ -875,7 +880,7 @@ class RestoreFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
+export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.ObjectExplorerCreateSessionRequest.type,
 		protocol.ObjectExplorerExpandRequest.type,
@@ -962,7 +967,7 @@ class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class ScriptingFeature extends SqlOpsFeature<undefined> {
+export class ScriptingFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.ScriptingRequest.type,
 		protocol.ScriptingCompleteNotification.type
@@ -1009,7 +1014,7 @@ class ScriptingFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class TaskServicesFeature extends SqlOpsFeature<undefined> {
+export class TaskServicesFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.ListTasksRequest.type,
 		protocol.CancelTaskRequest.type,
@@ -1074,7 +1079,7 @@ class TaskServicesFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class FileBrowserFeature extends SqlOpsFeature<undefined> {
+export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.FileBrowserOpenRequest.type,
 		protocol.FileBrowserOpenedNotification.type,
@@ -1172,7 +1177,7 @@ class FileBrowserFeature extends SqlOpsFeature<undefined> {
 	}
 }
 
-class ProfilerFeature extends SqlOpsFeature<undefined> {
+export class ProfilerFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.StartProfilingRequest.type,
 		protocol.StopProfilingRequest.type,
@@ -1264,6 +1269,21 @@ class ProfilerFeature extends SqlOpsFeature<undefined> {
  */
 export class SqlOpsDataClient extends LanguageClient {
 
+	private static readonly defaultFeatures: Array<ISqlopsFeature> = [
+		ConnectionFeature,
+		CapabilitiesFeature,
+		QueryFeature,
+		MetadataFeature,
+		AdminServicesFeature,
+		BackupFeature,
+		RestoreFeature,
+		ObjectExplorerFeature,
+		ScriptingFeature,
+		TaskServicesFeature,
+		FileBrowserFeature,
+		ProfilerFeature
+	];
+
 	private _sqlc2p: Ic2p;
 	private _sqlp2c: Ip2c;
 	private _providerId: string;
@@ -1280,33 +1300,27 @@ export class SqlOpsDataClient extends LanguageClient {
 		return this._providerId;
 	}
 
-	public constructor(name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions, forceDebug?: boolean);
-	public constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: LanguageClientOptions, forceDebug?: boolean);
-	public constructor(arg1: string, arg2: ServerOptions | string, arg3: LanguageClientOptions | ServerOptions, arg4?: boolean | LanguageClientOptions, arg5?: boolean) {
+	public constructor(name: string, serverOptions: ServerOptions, clientOptions: ClientOptions, forceDebug?: boolean);
+	public constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: ClientOptions, forceDebug?: boolean);
+	public constructor(arg1: string, arg2: ServerOptions | string, arg3: ClientOptions | ServerOptions, arg4?: boolean | ClientOptions, arg5?: boolean) {
+		let features: Array<ISqlopsFeature>;
 		if (is.string(arg2)) {
-			super(arg1, arg2, arg3 as ServerOptions, arg4 as LanguageClientOptions, arg5);
-			this._providerId = (arg4 as LanguageClientOptions).providerId;
+			super(arg1, arg2, arg3 as ServerOptions, arg4 as ClientOptions, arg5);
+			this._providerId = (arg4 as ClientOptions).providerId;
+			features = (arg4 as ClientOptions).features;
 		} else {
-			super(arg1, arg2 as ServerOptions, arg3 as LanguageClientOptions, arg4 as boolean);
-			this._providerId = (arg3 as LanguageClientOptions).providerId;
+			super(arg1, arg2 as ServerOptions, arg3 as ClientOptions, arg4 as boolean);
+			this._providerId = (arg3 as ClientOptions).providerId;
+			features = (arg3 as ClientOptions).features;
 		}
 		this._sqlc2p = c2p;
 		this._sqlp2c = p2c;
-		this.registerDataFeatures();
+		this.registerSqlopsFeatures(features || SqlOpsDataClient.defaultFeatures);
 	}
 
-	private registerDataFeatures() {
-		this.registerFeature(new ConnectionFeature(this));
-		this.registerFeature(new CapabilitiesFeature(this));
-		this.registerFeature(new QueryFeature(this));
-		this.registerFeature(new MetadataFeature(this));
-		this.registerFeature(new AdminServicesFeature(this));
-		this.registerFeature(new BackupFeature(this));
-		this.registerFeature(new RestoreFeature(this));
-		this.registerFeature(new ObjectExplorerFeature(this));
-		this.registerFeature(new ScriptingFeature(this));
-		this.registerFeature(new TaskServicesFeature(this));
-		this.registerFeature(new FileBrowserFeature(this));
-		this.registerFeature(new ProfilerFeature(this));
+	private registerSqlopsFeatures(features: Array<ISqlopsFeature>) {
+		features.map(f => {
+			new f(this);
+		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,14 +21,14 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 	return target[key];
 }
 
-export interface ISqlopsFeature {
+export interface ISqlOpsFeature {
 	new (client: SqlOpsDataClient);
 }
 
 export interface ClientOptions extends VSLanguageClientOptions {
 	providerId: string;
 	serverConnectionMetadata: any;
-	features?: Array<ISqlopsFeature>;
+	features?: Array<ISqlOpsFeature>;
 }
 
 /**
@@ -1269,7 +1269,7 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
  */
 export class SqlOpsDataClient extends LanguageClient {
 
-	private static readonly defaultFeatures: Array<ISqlopsFeature> = [
+	private static readonly defaultFeatures: Array<ISqlOpsFeature> = [
 		ConnectionFeature,
 		CapabilitiesFeature,
 		QueryFeature,
@@ -1303,7 +1303,7 @@ export class SqlOpsDataClient extends LanguageClient {
 	public constructor(name: string, serverOptions: ServerOptions, clientOptions: ClientOptions, forceDebug?: boolean);
 	public constructor(id: string, name: string, serverOptions: ServerOptions, clientOptions: ClientOptions, forceDebug?: boolean);
 	public constructor(arg1: string, arg2: ServerOptions | string, arg3: ClientOptions | ServerOptions, arg4?: boolean | ClientOptions, arg5?: boolean) {
-		let features: Array<ISqlopsFeature>;
+		let features: Array<ISqlOpsFeature>;
 		if (is.string(arg2)) {
 			super(arg1, arg2, arg3 as ServerOptions, arg4 as ClientOptions, arg5);
 			this._providerId = (arg4 as ClientOptions).providerId;
@@ -1318,7 +1318,7 @@ export class SqlOpsDataClient extends LanguageClient {
 		this.registerSqlopsFeatures(features || SqlOpsDataClient.defaultFeatures);
 	}
 
-	private registerSqlopsFeatures(features: Array<ISqlopsFeature>) {
+	private registerSqlopsFeatures(features: Array<ISqlOpsFeature>) {
 		features.map(f => {
 			this.registerFeature(new f(this));
 		});


### PR DESCRIPTION
adds a optional client option to specify features to register  at start up. This allows extensions to not register for features they don't actually provide. For example, currently in sqlops, credentials client and serialization client are both registering for every feature even though if you call them, they would fail. 

However, this change keep the current default behavior, being if you don't specify features, it will register the client for all features. We might want to change this in the future though.