### PR TITLE
Support new method to find OE nodes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -887,7 +887,8 @@ export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 		protocol.ObjectExplorerRefreshRequest.type,
 		protocol.ObjectExplorerCloseSessionRequest.type,
 		protocol.ObjectExplorerCreateSessionCompleteNotification.type,
-		protocol.ObjectExplorerExpandCompleteNotification.type
+		protocol.ObjectExplorerExpandCompleteNotification.type,
+		protocol.ObjectExplorerFindNodesRequest.type
 	];
 
 	constructor(client: SqlOpsDataClient) {
@@ -947,6 +948,16 @@ export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
+		let findNodes = (findNodesInfo: sqlops.FindNodesInfo): Thenable<any> => {
+			return client.sendRequest(protocol.ObjectExplorerFindNodesRequest.type, findNodesInfo).then(
+				r => r,
+				e => {
+					client.logFailedRequest(protocol.ObjectExplorerFindNodesRequest.type, e);
+					return Promise.resolve(undefined);
+				}
+			)
+		}
+
 		let registerOnSessionCreated = (handler: (response: sqlops.ObjectExplorerSession) => any): void => {
 			client.onNotification(protocol.ObjectExplorerCreateSessionCompleteNotification.type, handler);
 		};
@@ -961,6 +972,7 @@ export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 			createNewSession,
 			expandNode,
 			refreshNode,
+			findNodes,
 			registerOnExpandCompleted,
 			registerOnSessionCreated
 		});

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -511,6 +511,10 @@ export namespace ObjectExplorerCloseSessionRequest {
 	export const type = new RequestType<types.CloseSessionParams, types.CloseSessionResponse, void, void>('objectexplorer/closesession');
 }
 
+export namespace ObjectExplorerFindNodesRequest {
+	export const type = new RequestType<types.FindNodesParams, types.FindNodesResponse, void, void>('objectexplorer/findnodes');
+}
+
 // ------------------------------- < Object Explorer Events > ------------------------------------
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,19 @@ export interface CloseSessionResponse {
 	sessionId: string;
 }
 
+export interface FindNodesParams {
+	sessionId: string;
+	type: string;
+	schema: string;
+	name: string;
+	database: string;
+	parentObjectNames: string[];
+}
+
+export interface FindNodesResponse {
+	nodes: NodeInfo[];
+}
+
 export interface CategoryValue {
 	displayName: string;
 


### PR DESCRIPTION
Add a `findNodes` method on Object Explorer.

This PR goes along with the SQL Ops Studio changes at https://github.com/Microsoft/sqlopsstudio/pull/916 and the SQL Tools Service changes at https://github.com/Microsoft/sqltoolsservice/pull/589