### PR TITLE
rename project to sqlops-dataclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "dataprotocol-client",
+  "name": "sqlops-dataclient",
   "version": "0.1.6",
-  "description": "Client implementation for sqlops studio",
+  "description": "Data client implementation for sqlops studio",
   "main": "lib/main",
   "typings": "lib/main",
   "scripts": {


### PR DESCRIPTION
It would be complicated to use the dataprotocol-client name with npm since a package already exists with that name. So I am proposing changing the name to sqlops-dataclient, which follows the naming scheme of vscode-languageclient.