### PR TITLE
Profiler notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "engines": {
     "vscode": "*",
-    "sqlops": "*"
+    "sqlops": "feature/profilerNotifications"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "engines": {
     "vscode": "*",
-    "sqlops": "feature/profilerNotifications"
+    "sqlops": "*"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1268,16 +1268,29 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 			client.onNotification(protocol.ProfilerEventsAvailableNotification.type, (params: types.ProfilerEventsAvailableParams) => {
 				handler(<sqlops.ProfilerSessionEvents>{
 					sessionId: params.ownerUri,
-					events: params.events
+					events: params.events,
+					eventsLost: params.eventsLost
 				});
 			});
 		};
+
+		
+		let registerOnSessionStopped = (handler: (response: sqlops.ProfilerSessionStoppedParams) => any): void => {
+			client.onNotification(protocol.ProfilerSessionStoppedNotification.type, (params: types.ProfilerSessionStoppedParams) => {
+				handler(<sqlops.ProfilerSessionStoppedParams>{
+					ownerUri: params.ownerUri,
+					sessionId: params.sessionId,
+				});
+			});
+		};
+		
 
 		return sqlops.dataprotocol.registerProfilerProvider({
 			providerId: client.providerId,
 			connectSession,
 			disconnectSession,
 			registerOnSessionEventsAvailable,
+			registerOnSessionStopped,
 			startSession,
 			stopSession,
 			pauseSession

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -639,3 +639,7 @@ export namespace PauseProfilingRequest {
 export namespace ProfilerEventsAvailableNotification {
 	export const type = new NotificationType<types.ProfilerEventsAvailableParams, void>('profiler/eventsavailable');
 }
+
+export namespace ProfilerSessionStoppedNotification {
+	export const type = new NotificationType<types.ProfilerSessionStoppedParams, void>('profiler/sessionstopped');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -917,4 +917,24 @@ export interface ProfilerEventsAvailableParams {
 	 * New profiler events available
 	 */
 	events: ProfilerEvent[];
+
+	/**
+	 * If events may have been dropped
+	 */
+	eventsLost: boolean;
+}
+
+/**
+ * Profiler events available notification parameters
+ */
+export interface ProfilerSessionStoppedParams {
+	/**
+	 * Session owner URI
+	 */
+	ownerUri: string;
+
+	/**
+	 * Stopped session Id
+	 */
+	sessionId: number;
 }


### PR DESCRIPTION
Added a new parameter to events available so it can notify if events were lost. Added a new notification for if the session is stopped on the server.