### PR TITLE
Add profiler session templates, and ability to list all existing sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "engines": {
     "vscode": "*",
-    "sqlops": "*"
+    "sqlops": "profiler/sessionTemplates"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "engines": {
     "vscode": "*",
-    "sqlops": "profiler/sessionTemplates"
+    "sqlops": "*"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1225,10 +1225,10 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 	protected registerProvider(options: undefined): Disposable {
 		const client = this._client;
 
-		let startSession = (ownerUri: string): Thenable<boolean> => {
+		let startSession = (ownerUri: string, sessionName: string): Thenable<boolean> => {
 			let params: types.StartProfilingParams = {
 				ownerUri,
-				options: {}
+				sessionName
 			};
 
 			return client.sendRequest(protocol.StartProfilingRequest.type, params).then(
@@ -1263,6 +1263,20 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 				r => true,
 				e => {
 					client.logFailedRequest(protocol.PauseProfilingRequest.type, e);
+					return Promise.reject(e);
+				}
+			);
+		};
+
+		let getXEventSessions = (ownerUri: string): Thenable<string[]> => {
+			let params: types.GetXEventSessionsParams = {
+				ownerUri
+			};
+
+			return client.sendRequest(protocol.GetXEventSessionsRequest.type, params).then(
+				r => r.sessions,
+				e => {
+					client.logFailedRequest(protocol.GetXEventSessionsRequest.type, e);
 					return Promise.reject(e);
 				}
 			);
@@ -1305,7 +1319,8 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 			registerOnSessionStopped,
 			startSession,
 			stopSession,
-			pauseSession
+			pauseSession,
+			getXEventSessions
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1225,6 +1225,22 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 	protected registerProvider(options: undefined): Disposable {
 		const client = this._client;
 
+		let createSession = (ownerUri: string, createStatement:string, sessionName: string): Thenable<boolean> => {
+			let params: types.CreateXEventSessionParams = {
+				ownerUri,
+				createStatement,
+				sessionName
+			};
+
+			return client.sendRequest(protocol.CreateXEventSessionRequest.type, params).then(
+				r => true,
+				e => {
+					client.logFailedRequest(protocol.CreateXEventSessionRequest.type, e);
+					return Promise.reject(e);
+				}
+			);
+		}
+
 		let startSession = (ownerUri: string, sessionName: string): Thenable<boolean> => {
 			let params: types.StartProfilingParams = {
 				ownerUri,
@@ -1317,6 +1333,7 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 			disconnectSession,
 			registerOnSessionEventsAvailable,
 			registerOnSessionStopped,
+			createSession,
 			startSession,
 			stopSession,
 			pauseSession,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1225,11 +1225,11 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 	protected registerProvider(options: undefined): Disposable {
 		const client = this._client;
 
-		let createSession = (ownerUri: string, createStatement:string, sessionName: string): Thenable<boolean> => {
+		let createSession = (ownerUri: string, sessionName:string, template: sqlops.ProfilerSessionTemplate): Thenable<boolean> => {
 			let params: types.CreateXEventSessionParams = {
 				ownerUri,
-				createStatement,
-				sessionName
+				sessionName,
+				template
 			};
 
 			return client.sendRequest(protocol.CreateXEventSessionRequest.type, params).then(
@@ -1325,6 +1325,16 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 				});
 			});
 		};
+
+		let registerOnProfilerSessionCreated = (handler: (response: sqlops.ProfilerSessionCreatedParams) => any): void => {
+			client.onNotification(protocol.ProfilerSessionCreatedNotification.type, (params: types.ProfilerSessionCreatedParams) => {
+				handler(<sqlops.ProfilerSessionCreatedParams>{
+					ownerUri: params.ownerUri,
+					sessionName: params.sessionName,
+					templateName: params.templateName
+				});
+			});
+		};
 		
 
 		return sqlops.dataprotocol.registerProfilerProvider({
@@ -1333,6 +1343,7 @@ export class ProfilerFeature extends SqlOpsFeature<undefined> {
 			disconnectSession,
 			registerOnSessionEventsAvailable,
 			registerOnSessionStopped,
+			registerOnProfilerSessionCreated,
 			createSession,
 			startSession,
 			stopSession,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -641,6 +641,10 @@ export namespace PauseProfilingRequest {
 	export const type = new RequestType<types.PauseProfilingParams, types.PauseProfilingResponse, void, void>('profiler/pause');
 }
 
+export namespace GetXEventSessionsRequest {
+	export const type = new RequestType<types.GetXEventSessionsParams, types.GetXEventSessionsResponse, void, void>('profiler/getsessions');
+}
+
 export namespace ProfilerEventsAvailableNotification {
 	export const type = new NotificationType<types.ProfilerEventsAvailableParams, void>('profiler/eventsavailable');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -629,6 +629,10 @@ export namespace FileBrowserCloseRequest {
 
 // ------------------------------- < Profiler Events > ------------------------------------
 
+export namespace CreateXEventSessionRequest {
+	export const type = new RequestType<types.CreateXEventSessionParams, types.CreateXEventSessionResponse, void, void>('profiler/createsession');
+}
+
 export namespace StartProfilingRequest {
 	export const type = new RequestType<types.StartProfilingParams, types.StartProfilingResponse, void, void>('profiler/start');
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -656,3 +656,7 @@ export namespace ProfilerEventsAvailableNotification {
 export namespace ProfilerSessionStoppedNotification {
 	export const type = new NotificationType<types.ProfilerSessionStoppedParams, void>('profiler/sessionstopped');
 }
+
+export namespace ProfilerSessionCreatedNotification {
+	export const type = new NotificationType<types.ProfilerSessionCreatedParams, void>('profiler/sessioncreated');
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -850,14 +850,14 @@ export interface CreateXEventSessionParams {
 	ownerUri: string;
 
 	/**
-	 * T-SQL Create statement
-	 */
-	createStatement: string;
-
-	/**
 	 * Session name
 	 */
 	sessionName: string;
+
+	/**
+	 * Profiler Session template
+	 */
+	template: ProfilerSessionTemplate;
 }
 
 export interface CreateXEventSessionResponse {}
@@ -941,6 +941,26 @@ export interface ProfilerEvent {
 }
 
 /**
+ * Profiler Session Template
+ */
+export interface ProfilerSessionTemplate {
+	/**
+	 * Template name
+	 */
+	name: string;
+
+	/**
+	 * Default view for template
+	 */
+	defaultView: string;
+
+	/**
+	 * TSQL for creating a session
+	 */
+	createStatement: string;
+}
+
+/**
  * Profiler events available notification parameters
  */
 export interface ProfilerEventsAvailableParams {
@@ -973,4 +993,24 @@ export interface ProfilerSessionStoppedParams {
 	 * Stopped session Id
 	 */
 	sessionId: number;
+}
+
+/**
+ * Profiler session created notification parameters
+ */
+export interface ProfilerSessionCreatedParams {
+	/**
+	 * Session owner URI
+	 */
+	ownerUri: string;
+
+	/**
+	 * Created session name
+	 */
+	sessionName: string;
+
+	/**
+	 * Template used to create session
+	 */
+	templateName: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -843,6 +843,28 @@ export class TableMetadata {
 /**
  * Parameters to start a profiler session
  */
+export interface CreateXEventSessionParams {
+	/**
+	 * Session Owner URI
+	 */
+	ownerUri: string;
+
+	/**
+	 * T-SQL Create statement
+	 */
+	createStatement: string;
+
+	/**
+	 * Session name
+	 */
+	sessionName: string;
+}
+
+export interface CreateXEventSessionResponse {}
+
+/**
+ * Parameters to start a profiler session
+ */
 export interface StartProfilingParams {
 	/**
 	 * Session Owner URI

--- a/src/types.ts
+++ b/src/types.ts
@@ -850,15 +850,12 @@ export interface StartProfilingParams {
 	ownerUri: string;
 
 	/**
-	 * Session options
+	 * Session name
 	 */
-	options: {};
+	sessionName: string;
 }
 
-export interface StartProfilingResponse {
-	succeeded: string;
-	errorMessage: string;
-}
+export interface StartProfilingResponse {}
 
 /**
  * Parameters to stop a profiler session
@@ -883,6 +880,23 @@ export interface PauseProfilingParams {
 }
 
 export interface PauseProfilingResponse {}
+
+/**
+ * Parameters to get a list of XEvent sessions
+ */
+export interface GetXEventSessionsParams {
+	/**
+	 * Session Owner URI
+	 */
+	ownerUri: string;
+}
+
+export interface GetXEventSessionsResponse {
+	/**
+	 * List of all running XEvent Sessions on target server
+	 */
+	sessions: string[];
+}
 
 /**
  * Profiler Event


### PR DESCRIPTION
This PR changes the existing startSession functionality, and adds two new request types, CreateSession and getXEventSessions. It also adds a new notification to SQL Ops when a new session has been successfully created.