### PR TITLE
Update LIB files to include recent connection string changes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -160,6 +160,12 @@ class ConnectionFeature extends SqlOpsFeature {
                 return Promise.resolve(undefined);
             });
         };
+        let buildConnectionInfo = (connectionString) => {
+            return client.sendRequest(protocol.BuildConnectionInfoRequest.type, connectionString).then(r => r, e => {
+                client.logFailedRequest(protocol.BuildConnectionInfoRequest.type, e);
+                return Promise.resolve(e);
+            });
+        };
         let rebuildIntelliSenseCache = (ownerUri) => {
             let params = {
                 ownerUri
@@ -191,6 +197,7 @@ class ConnectionFeature extends SqlOpsFeature {
             changeDatabase,
             listDatabases,
             getConnectionString,
+            buildConnectionInfo,
             rebuildIntelliSenseCache,
             registerOnConnectionChanged,
             registerOnIntelliSenseCacheComplete,

--- a/lib/protocol.d.ts
+++ b/lib/protocol.d.ts
@@ -104,7 +104,7 @@ export interface ConnectParams {
     /**
      * Details for creating the connection
      */
-    connection: types.ConnectionDetails;
+    connection: sqlops.ConnectionInfo;
 }
 export declare namespace ConnectionRequest {
     const type: RequestType<ConnectParams, boolean, void, void>;
@@ -167,6 +167,9 @@ export declare class GetConnectionStringParams {
 }
 export declare namespace GetConnectionStringRequest {
     const type: RequestType<GetConnectionStringParams, string, void, void>;
+}
+export declare namespace BuildConnectionInfoRequest {
+    const type: RequestType<string, sqlops.ConnectionInfo, void, void>;
 }
 /**
  * Parameters to provide when sending a language flavor changed notification
@@ -343,7 +346,7 @@ export declare namespace EditSubsetRequest {
     const type: RequestType<sqlops.EditSubsetParams, sqlops.EditSubsetResult, void, void>;
 }
 export declare namespace ObjectExplorerCreateSessionRequest {
-    const type: RequestType<types.ConnectionDetails, types.CreateSessionResponse, void, void>;
+    const type: RequestType<sqlops.ConnectionInfo, types.CreateSessionResponse, void, void>;
 }
 export declare namespace ObjectExplorerExpandRequest {
     const type: RequestType<types.ExpandParams, boolean, void, void>;

--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -87,6 +87,12 @@ var GetConnectionStringRequest;
 (function (GetConnectionStringRequest) {
     GetConnectionStringRequest.type = new vscode_languageclient_1.RequestType('connection/getconnectionstring');
 })(GetConnectionStringRequest = exports.GetConnectionStringRequest || (exports.GetConnectionStringRequest = {}));
+// ------------------------------- < Get Connection String Request > ---------------------------------------
+// Get Connection String request callback declaration
+var BuildConnectionInfoRequest;
+(function (BuildConnectionInfoRequest) {
+    BuildConnectionInfoRequest.type = new vscode_languageclient_1.RequestType('connection/buildconnectioninfo');
+})(BuildConnectionInfoRequest = exports.BuildConnectionInfoRequest || (exports.BuildConnectionInfoRequest = {}));
 // ------------------------------- < Language Flavor Changed Notification > ---------------------------------------
 var LanguageFlavorChangedNotification;
 (function (LanguageFlavorChangedNotification) {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -90,15 +90,6 @@ export interface FeatureMetadataProvider {
     optionsMetadata: ServiceOption[];
 }
 /**
- * Parameters to initialize a connection to a database
- */
-export interface ConnectionDetails {
-    /**
-     * connection options
-     */
-    options: {};
-}
-/**
  * Summary that identifies a unique database connection.
  */
 export declare class ConnectionSummary {
@@ -612,7 +603,7 @@ export interface ScriptingParams {
     /**
      * Connection details for the ScriptingParams
      */
-    connectionDetails: ConnectionDetails;
+    connectionDetails: sqlops.ConnectionInfo;
     /**
      * Owner URI of the connection
      */


### PR DESCRIPTION
The previous update to the DMP contracts didn't include updates to the files in `lib` so the update isn't being picked up by dependencies.