### PR TITLE
hook up the languageflavorchanged event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -279,6 +279,10 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 			});
 		};
 
+		sqlops.dataprotocol.onDidChangeLanguageFlavor((params) => {
+            client.sendNotification(protocol.LanguageFlavorChangedNotification.type, params);
+        });
+
 		return sqlops.dataprotocol.registerConnectionProvider({
 			providerId: client.providerId,
 			connect,


### PR DESCRIPTION
this event is not hooked up causing mssql to run diagnostics for non-mssql query files.