### PR TITLE
extend the list databases request

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 }
 
 export interface ISqlOpsFeature {
-	new (client: SqlOpsDataClient);
+	new(client: SqlOpsDataClient);
 }
 
 export interface ClientOptions extends VSLanguageClientOptions {
@@ -214,7 +214,7 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 
 		let listDatabases = (ownerUri: string): Thenable<azdata.ListDatabasesResult> => {
 			let params: protocol.ListDatabasesParams = {
-				ownerUri
+				ownerUri: ownerUri
 			};
 
 			return client.sendRequest(protocol.ListDatabasesRequest.type, params).then(
@@ -567,12 +567,12 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 		};
 
 		let initializeEdit = (
-				ownerUri: string,
-				schemaName: string,
-				objectName: string,
-				objectType: string,
-				LimitResults: number,
-				queryString: string): Thenable<void> => {
+			ownerUri: string,
+			schemaName: string,
+			objectName: string,
+			objectType: string,
+			LimitResults: number,
+			queryString: string): Thenable<void> => {
 			let filters: azdata.EditInitializeFiltering = { LimitResults };
 			let params: azdata.EditInitializeParams = { ownerUri, schemaName, objectName, objectType, filters, queryString };
 			return client.sendRequest(protocol.EditInitializeRequest.type, params).then(
@@ -703,10 +703,15 @@ export class MetadataFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let getDatabases = (ownerUri: string): Thenable<string[]> => {
-			let params: protocol.ListDatabasesParams = { ownerUri };
+		let getDatabases = (ownerUri: string): Thenable<string[] | azdata.DatabaseDetail[]> => {
+			let params: protocol.ListDatabasesParams = {
+				ownerUri: ownerUri,
+				includeDetails: true
+			};
 			return client.sendRequest(protocol.ListDatabasesRequest.type, params).then(
-				r => r.databaseNames,
+				r => {
+					return r.databaseNames ? r.databaseNames : r.databases;
+				},
 				e => {
 					client.logFailedRequest(protocol.ListDatabasesRequest.type, e);
 					return Promise.resolve(undefined);
@@ -1089,17 +1094,17 @@ export class ScriptingFeature extends SqlOpsFeature<undefined> {
 		const client = this._client;
 
 		let scriptAsOperation = (
-				connectionUri: string,
-				operation: azdata.ScriptOperation,
-				metadata: azdata.ObjectMetadata,
-				paramDetails: azdata.ScriptingParamDetails): Thenable<azdata.ScriptingResult> => {
+			connectionUri: string,
+			operation: azdata.ScriptOperation,
+			metadata: azdata.ObjectMetadata,
+			paramDetails: azdata.ScriptingParamDetails): Thenable<azdata.ScriptingResult> => {
 			return client.sendRequest(protocol.ScriptingRequest.type,
 				client.sqlc2p.asScriptingParams(connectionUri, operation, metadata, paramDetails)).then(
-				r => r,
-				e => {
-					client.logFailedRequest(protocol.ScriptingRequest.type, e);
-					return Promise.resolve(undefined);
-				}
+					r => r,
+					e => {
+						client.logFailedRequest(protocol.ScriptingRequest.type, e);
+						return Promise.resolve(undefined);
+					}
 				);
 		};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -703,7 +703,7 @@ export class MetadataFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let getDatabases = (ownerUri: string): Thenable<string[] | azdata.DatabaseDetail[]> => {
+		let getDatabases = (ownerUri: string): Thenable<string[] | azdata.DatabaseInfo[]> => {
 			let params: protocol.ListDatabasesParams = {
 				ownerUri: ownerUri,
 				includeDetails: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -214,7 +214,7 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 
 		let listDatabases = (ownerUri: string): Thenable<azdata.ListDatabasesResult> => {
 			let params: protocol.ListDatabasesParams = {
-				ownerUri: ownerUri
+				ownerUri
 			};
 
 			return client.sendRequest(protocol.ListDatabasesRequest.type, params).then(
@@ -709,9 +709,7 @@ export class MetadataFeature extends SqlOpsFeature<undefined> {
 				includeDetails: true
 			};
 			return client.sendRequest(protocol.ListDatabasesRequest.type, params).then(
-				r => {
-					return r.databaseNames ? r.databaseNames : r.databases;
-				},
+				r => { return r.databaseNames ? r.databaseNames : r.databases; },
 				e => {
 					client.logFailedRequest(protocol.ListDatabasesRequest.type, e);
 					return Promise.resolve(undefined);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -208,6 +208,7 @@ export namespace ChangeDatabaseRequest {
 export class ListDatabasesParams {
 	// Connection information to use for querying master
 	public ownerUri: string;
+	public includeDetails?: boolean;
 }
 
 // List databases request callback declaration


### PR DESCRIPTION
add includeDetails option to the request parameter, for getDatabases, handle the data client that hasn't implemented the new parameter which will still return databaseNames.

in order to implement https://github.com/microsoft/azuredatastudio/issues/10185, I need to make the following changes:
1. extend the ListDatabasesRequest related interfaces in azdata.d.ts in ADS repo
1. update the dataprotocol-client repo to handle the extended ListDatabaseRequest and response properly - depends on step NO.1
1. update SqlToolsService to implement extended ListDatabasesRequest handler
1. update ADS repo to implement the UI changes. depends on all steps above

this change is step 2.