### PR TITLE
add optional context to sqlopsfeature

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import * as is from 'vscode-languageclient/lib/utils/is';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 
 import * as azdata from 'azdata';
-
+import { ExtensionContext } from 'vscode';
 import { c2p, Ic2p } from './codeConverter';
 
 import * as protocol from './protocol';
@@ -22,7 +22,7 @@ function ensure<T, K extends keyof T>(target: T, key: K): T[K] {
 }
 
 export interface ISqlOpsFeature {
-	new(client: SqlOpsDataClient);
+	new(client: SqlOpsDataClient, appContext?: ExtensionContext);
 }
 
 export interface ClientOptions extends VSLanguageClientOptions {


### PR DESCRIPTION
Currently DynamicFeatures can only use the client because of its interface. To use the secret store, we need the extension context (https://github.com/microsoft/vscode/blob/main/src/vs/vscode.d.ts#L5982).

We cannot use the Credential Feature as a Static Feature because we expose that API in azdata for CredentialsProvider, so I added an optional parameter here.