### PR TITLE
Add parentName property to the ScriptingObject type

### DIFF
--- a/src/codeConverter.ts
+++ b/src/codeConverter.ts
@@ -36,7 +36,10 @@ function asScriptingParams(
 	let scriptingObject: types.ScriptingObject = {
 		type: metadata.metadataTypeName,
 		schema: metadata.schema,
-		name: metadata.name
+		name: metadata.name,
+		// cast to any since azdata needs to be updated to pickup this new field
+		// TODO: remove cast once updated azdata is published (8/24/2021 - karlb)
+		parentName: (<any>metadata).parentName
 	};
 	let targetDatabaseEngineEdition = paramDetails.targetDatabaseEngineEdition;
 	let targetDatabaseEngineType = paramDetails.targetDatabaseEngineType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -732,6 +732,11 @@ export interface ScriptingObject {
 	 * The database object name
 	 */
 	name: string;
+
+	/**
+	 * The parent object name which is needed for scripting subobjects like triggers or indexes
+	 */
+	parentName: string;
 }
 
 export interface ScriptingParams {


### PR DESCRIPTION
This is a portion of the fix for https://github.com/microsoft/azuredatastudio/issues/2093.  I'll add links to PRs for ADS and STS once available.