### PR TITLE
bump version to 1.2.4 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Client implementation for sqlops studio",
   "main": "lib/main",
   "typings": "lib/main",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dataprotocol-client",
   "version": "1.2.4",
-  "description": "Client implementation for sqlops studio",
+  "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",
   "scripts": {

--- a/src/azdata.proposed.d.ts
+++ b/src/azdata.proposed.d.ts
@@ -767,6 +767,13 @@ declare module 'azdata' {
 		delete?: boolean;
 	}
 
+	export enum CardType {
+		/**
+		 * Card with the icon as a background image
+		 */
+		Image = 'Image'
+	}
+
 	export namespace workspace {
 		/**
 		 * Creates and enters a workspace at the specified location


### PR DESCRIPTION
This is required for https://github.com/microsoft/azuredatastudio/pull/16883 to work, and needs to be merged into the release branch once completed. Also it updates the azdata.proposed file to match the current file in ADS.