### PR TITLE
Bump azdata version to 1.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "vscode-languageclient": "5.2.1"
   },
   "devDependencies": {
-    "@types/azdata": "^1.26.0",
+    "@types/azdata": "^1.32.0",
     "@types/node": "^12.11.7",
     "@types/vscode": "^1.51.0",
     "tslint": "^6.1.3",

--- a/src/azdata.proposed.d.ts
+++ b/src/azdata.proposed.d.ts
@@ -948,4 +948,22 @@ declare module 'azdata' {
 		 */
 		connectionUriChanged(newUri: string, oldUri: string): Thenable<void>;
 	}
+
+	// Temporary workaround for no AccountSecurityToken in 1.32 azdata release.
+
+	export namespace accounts {
+		/**
+		 * The token used to authenticate an account.
+		 */
+		 export interface AccountSecurityToken {
+			/**
+			 * The token to use
+			 */
+			token: string,
+			/**
+			 * What type of token this is (such as Bearer)
+			 */
+			tokenType?: string | undefined
+		}
+	}
 }

--- a/src/azdata.proposed.d.ts
+++ b/src/azdata.proposed.d.ts
@@ -949,7 +949,7 @@ declare module 'azdata' {
 		connectionUriChanged(newUri: string, oldUri: string): Thenable<void>;
 	}
 
-	// Temporary workaround for no AccountSecurityToken in 1.32 azdata release.
+	// Temporary workaround for no AccountSecurityToken in 1.32 azdata release. (remove after 1.33 release)
 
 	export namespace accounts {
 		/**


### PR DESCRIPTION
This is to keep the azdata module up to date, and adds a workaround for the no AzureSecurityToken issue when compiling.