### PR TITLE
Backup/Restore Managed Instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",

--- a/src/main.ts
+++ b/src/main.ts
@@ -844,7 +844,8 @@ export class AdminServicesFeature extends SqlOpsFeature<undefined> {
 export class BackupFeature extends SqlOpsFeature<undefined> {
 	private static readonly messagesTypes: RPCMessageType[] = [
 		protocol.BackupRequest.type,
-		protocol.BackupConfigInfoRequest.type
+		protocol.BackupConfigInfoRequest.type,
+		protocol.CreateSasRequest.type
 	];
 
 	constructor(client: SqlOpsDataClient) {
@@ -887,10 +888,22 @@ export class BackupFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
+		let createSas = (blobContainerUri: string): Thenable<azdata.CreateSasResponse> => {
+			let params: types.CreateSasParams = { blobContainerUri };
+			return client.sendRequest(protocol.CreateSasRequest.type, params).then(
+				r => r.sharedAccessSignature,
+				e => {
+					client.logFailedRequest(protocol.BackupConfigInfoRequest.type, e);
+					return Promise.resolve(undefined);
+				}
+			)
+		}
+
 		return azdata.dataprotocol.registerBackupProvider({
 			providerId: client.providerId,
 			backup,
-			getBackupConfigInfo
+			getBackupConfigInfo,
+			createSas
 		});
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -888,16 +888,16 @@ export class BackupFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let createSas = (blobContainerUri: string): Thenable<azdata.CreateSasResponse> => {
-			let params: types.CreateSasParams = { blobContainerUri };
+		let createSas = (ownerUri: string, blobContainerUri: string, blobContainerKey: string, storageAccountName: string): Thenable<azdata.CreateSasResponse> => {
+			let params: types.CreateSasParams = { ownerUri, blobContainerUri, blobContainerKey, storageAccountName };
 			return client.sendRequest(protocol.CreateSasRequest.type, params).then(
-				r => r.sharedAccessSignature,
+				r => r,
 				e => {
-					client.logFailedRequest(protocol.BackupConfigInfoRequest.type, e);
+					client.logFailedRequest(protocol.CreateSasRequest.type, e);
 					return Promise.resolve(undefined);
 				}
-			)
-		}
+			);
+		};
 
 		return azdata.dataprotocol.registerBackupProvider({
 			providerId: client.providerId,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -70,6 +70,12 @@ export interface ConnectionClientCapabilities {
 		 */
 		dynamicRegistration?: boolean;
 	};
+	blob?: {
+		/**
+		 *
+		 */
+		 dynamicRegistration?: boolean;
+	};
 }
 
 export interface ClientCapabilities extends VSClientCapabilities {
@@ -634,7 +640,7 @@ export namespace BackupConfigInfoRequest {
 }
 
 export namespace CreateSasRequest {
-	export const type = new RequestType<types.CreateSasParams, azdata.CreateSasResponse, void, void>('backup/createsas');
+	export const type = new RequestType<types.CreateSasParams, azdata.CreateSasResponse, void, void>('blob/createsas');
 }
 
 export namespace RestoreRequest {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -634,7 +634,7 @@ export namespace BackupConfigInfoRequest {
 }
 
 export namespace CreateSasRequest {
-	export const type = new RequestType<types.CreateSasParams, types.CreateSasResponse, void, void>('backup/createsas');
+	export const type = new RequestType<types.CreateSasParams, azdata.CreateSasResponse, void, void>('backup/createsas');
 }
 
 export namespace RestoreRequest {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -633,6 +633,10 @@ export namespace BackupConfigInfoRequest {
 	export const type = new RequestType<types.DefaultDatabaseInfoParams, types.BackupConfigInfoResponse, void, void>('backup/backupconfiginfo');
 }
 
+export namespace CreateSasRequest {
+	export const type = new RequestType<types.CreateSasParams, types.CreateSasResponse, void, void>('backup/createsas');
+}
+
 export namespace RestoreRequest {
 	export const type = new RequestType<types.RestoreParams, azdata.RestoreResponse, void, void>('restore/restore');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,7 +303,6 @@ export interface CreateSasParams {
 	storageAccountName: string;
 }
 
-
 export interface CreateSasResponse {
 	sharedAccessSignature: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -296,6 +296,14 @@ export interface BackupConfigInfoResponse {
 	backupConfigInfo: azdata.BackupConfigInfo;
 }
 
+export interface CreateSasParams {
+	blobContainerUri: string;
+}
+
+export interface CreateSasResponse {
+	sharedAccessSignature: string;
+}
+
 export interface CreateLoginParams {
 	ownerUri: string;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,8 +297,12 @@ export interface BackupConfigInfoResponse {
 }
 
 export interface CreateSasParams {
+	ownerUri: string;
 	blobContainerUri: string;
+	blobContainerKey: string;
+	storageAccountName: string;
 }
+
 
 export interface CreateSasResponse {
 	sharedAccessSignature: string;


### PR DESCRIPTION
I added the createSas method to the backup provider. It's needed for creating a shared access signature for the backup/restore blob container.

This method should be used when the user wants to back up the database to the URL or restore it from the URL. A shared access signature is an expiring secret string that can be used to store something on a blob container. After creating SAS, it should be stored in the MSSQL sys.credential table. Method createSas does these two things: it creates SAS and stores it in sys.credentials.

The parameters are:

- ownerUri: SQL connection string, needed for storing SAS on the MSSQL
- blobContainerUri: URI of the blob container for which the method creates SAS (format: https://**myaccount**.blob.core.windows.net/**mycontainer**)
- blobContainerKey: blob container key needed for creating SAS for the blob
- storageAccountName: name of the storage account. It could be parsed from blob container URI, but I found it easier to pass it as a separate parameter. 

You can see the flow here:
![backup restore url drawio](https://user-images.githubusercontent.com/28262823/158565797-3dfddb00-8ad5-44cc-bb82-f6d8a6fb757a.png)

From the UI point of view, this is the RPC that's going to be called when the user clicks Create Credentials button on the URL browser dialog:
![image](https://user-images.githubusercontent.com/28262823/158575268-c50ef14d-d36c-4d04-bd8b-8cde2544ef89.png)
