### PR TITLE
ADS Enhancement - Support Sending Query Results to a File

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -509,6 +509,7 @@ export interface IResultMessage {
 	isError: boolean;
 	time: string;
 	message: string;
+	hasRowCount?: boolean;
 }
 
 export interface EditRow {


### PR DESCRIPTION
This PR is associated with this other PR that was created for Azure Data Studio (ADS): https://github.com/microsoft/azuredatastudio/pull/18822.

This PR adds a has row count flag to the IResultMessage interface. The row count flag is intended to help ADS organize query results and query messages, so they may be written to a file.