### PR TITLE
Update connection info typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -165,34 +165,44 @@ export class ConnectionCompleteParams {
 	public ownerUri: string;
 
 	/**
-	 * connection id returned from service host.
+	 * Connection id returned from service host, if the connection was successful.
 	 */
-	public connectionId: string;
+	public connectionId?: string | undefined;
 
 	/**
-	 * Full stack trace from the engine and service host.
+	 * Additional optional detailed error messages from the engine or service host, if an error occurred.
 	 */
-	public messages: string;
+	public messages?: string | undefined;
 
 	/**
-	 * Main error message(s) returned from the engine and service host, if any.
+	 * Error message returned from the engine or service host, if an error occurred.
 	 */
-	public errorMessage: string;
+	public errorMessage?: string | undefined;
 
 	/**
-	 * Error number returned from the engine, if any.
+	 * Error number returned from the engine or server host, if an error occurred.
 	 */
-	public errorNumber: number;
+	public errorNumber?: number | undefined;
 
 	/**
-	 * Information about the connected server.
+	 * Information about the connected server, if the connection was successful.
 	 */
-	public serverInfo: ServerInfo;
+	public serverInfo?: ServerInfo | undefined;
 
 	/**
-	 * information about the actual connection established
+	 * Information about the actual connection established, if the connection was successful.
 	 */
-	public connectionSummary: ConnectionSummary;
+	public connectionSummary?: ConnectionSummary | undefined;
+
+	/**
+	 * Whether the server version is supported by the provider. Default is to assume true.
+	 */
+	public isSupportedVersion?: boolean | undefined;
+
+	/**
+	 * Additional optional message with details about why the version isn't supported.
+	 */
+	public unsupportedVersionMessage?: string | undefined;
 }
 
 /**


### PR DESCRIPTION
Original PR : https://github.com/microsoft/sqlops-dataprotocolclient/pull/65

Companion PRs: 

https://github.com/microsoft/azuredatastudio/pull/20525
https://github.com/microsoft/sqltoolsservice/pull/1665

I'm further updating this to : 

1. Fix the actual types to be correct - most of the properties here can be null based on whether the connection was successful or not so making that explicit to help avoid errors with not properly checking them. This is technically a breaking change for anyone who might be compiling in strict mode - but given that this is just fixing the typings to be correct (we're currently sending null for those values) it's better to have it be correct so that consumers can fix it themselves when they update their typings. This doesn't affect anything at runtime. 
2. Update the descriptions to be more accurate/generic