### PR TITLE
Add support for `query/saveMarkdown` request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,6 +319,7 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 		protocol.QueryExecutionOptionsRequest.type,
 		protocol.SaveResultsAsCsvRequest.type,
 		protocol.SaveResultsAsJsonRequest.type,
+		protocol.SaveResultsAsMarkdownRequest.type,
 		protocol.SaveResultsAsExcelRequest.type,
 		protocol.SaveResultsAsXmlRequest.type,
 		protocol.EditCommitRequest.type,
@@ -494,6 +495,14 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 						undefined,
 						e => {
 							client.logFailedRequest(protocol.SaveResultsAsJsonRequest.type, e);
+							return Promise.reject(e);
+						}
+					);
+				case 'markdown':
+					return client.sendRequest(protocol.SaveResultsAsMarkdownRequest.type, requestParams).then (
+						undefined,
+						e => {
+							client.logFailedRequest(protocol.SaveResultsAsMarkdownRequest.type, e);
 							return Promise.reject(e);
 						}
 					);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -413,6 +413,13 @@ export namespace SaveResultsAsJsonRequest {
 }
 // --------------------------------- </ Save Results as JSON Request > ------------------------------------------
 
+// --------------------------------- < Save Results as Markdown Request > ------------------------------------------
+// save results in Markdown format
+export namespace SaveResultsAsMarkdownRequest {
+	export const type = new RequestType<azdata.SaveResultsRequestParams, azdata.SaveResultRequestResult, void, void>('query/saveMarkdown');
+}
+// --------------------------------- </ Save Results as JSON Request > ------------------------------------------
+
 // --------------------------------- < Save Results as Excel Request > ------------------------------------------
 // save results in Excel format
 export namespace SaveResultsAsExcelRequest {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -418,7 +418,7 @@ export namespace SaveResultsAsJsonRequest {
 export namespace SaveResultsAsMarkdownRequest {
 	export const type = new RequestType<azdata.SaveResultsRequestParams, azdata.SaveResultRequestResult, void, void>('query/saveMarkdown');
 }
-// --------------------------------- </ Save Results as JSON Request > ------------------------------------------
+// --------------------------------- </ Save Results as Markdown Request > -----------------------------------------
 
 // --------------------------------- < Save Results as Excel Request > ------------------------------------------
 // save results in Excel format


### PR DESCRIPTION
**Description**: This PR adds the necessary code to wire up the `query/saveMarkdown` request that is proposed in microsoft/sqltoolsservice#1705. This change will be used by [insert ADS PR here] to connect between sqltoolsservice and ADS.

**Testing**:
To test:
* `yarn compile` on sqlops-dataprotocolclient
* Pull down microsoft/azuredatastudio#[insertADSPRHere]
* In ADS, modify extensions/mssql/package.json to point to this local build of dataprotocolclient
* `yarn compile` on ADS
* Pull down microsoft/sqltoolsservice#1705
* Build solution on sqltoolsservice
* Copy sqltoolsservice bin folder to extensions/mssql/sqltoolsservice drop
* Launch ADS
* Run a query that selects something
* Observe new button on grid for exporting to Markdown
* Observe new right click action to export to Markdown on the grid
* Try it! Observe that it outputs a markdown file