### PR TITLE
Bumping to 1.3.4 to create a new release that includes the lib folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",


### PR DESCRIPTION
Messed up 1.3.3 by not including the `lib` files in the port.  Bumping the version number again to force clients that may have downloaded the lib-less 1.3.3 to download a new release.