### PR TITLE
Remove duplicated types

### DIFF
--- a/src/codeConverter.ts
+++ b/src/codeConverter.ts
@@ -37,10 +37,8 @@ function asScriptingParams(
 		type: metadata.metadataTypeName,
 		schema: metadata.schema,
 		name: metadata.name,
-		// cast to any since azdata needs to be updated to pickup this new field
-		// TODO: remove cast once updated azdata is published (8/24/2021 - karlb)
-		parentName: (<any>metadata).parentName,
-		parentTypeName: (<any>metadata).parentTypeName
+		parentName: metadata.parentName,
+		parentTypeName: metadata.parentTypeName
 	};
 	let targetDatabaseEngineEdition = paramDetails.targetDatabaseEngineEdition;
 	let targetDatabaseEngineType = paramDetails.targetDatabaseEngineType;

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,12 +289,7 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 		};
 
 		let registerOnConnectionChanged = (handler: (changedConnInfo: azdata.ChangedConnectionInfo) => any): void => {
-			client.onNotification(protocol.ConnectionChangedNotification.type, (params: protocol.ConnectionChangedParams) => {
-				handler({
-					connectionUri: params.ownerUri,
-					connection: params.connection
-				});
-			});
+			client.onNotification(protocol.ConnectionChangedNotification.type, handler);
 		};
 
 		azdata.dataprotocol.onDidChangeLanguageFlavor((params) => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -123,31 +123,16 @@ export namespace ConnectionRequest {
 
 
 export namespace ConnectionCompleteNotification {
-	export const type = new NotificationType<types.ConnectionCompleteParams, void>('connection/complete');
+	export const type = new NotificationType<azdata.ConnectionInfoSummary, void>('connection/complete');
 }
 
 // ------------------------------- < Connection Changed Event > -------------------------------------
 
 /**
- * Parameters for the ConnectionChanged notification.
- */
-export class ConnectionChangedParams {
-	/**
-	 * Owner URI of the connection that changed.
-	 */
-	public ownerUri: string;
-
-	/**
-	 * Summary of details containing any connection changes.
-	 */
-	public connection: types.ConnectionSummary;
-}
-
-/**
  * Connection changed event callback declaration.
  */
 export namespace ConnectionChangedNotification {
-	export const type = new NotificationType<ConnectionChangedParams, void>('connection/connectionchanged');
+	export const type = new NotificationType<azdata.ChangedConnectionInfo, void>('connection/connectionchanged');
 }
 
 // ------------------------------- < Password Change for Connection Event > -------------------------------------
@@ -504,7 +489,7 @@ export namespace ScriptingRequest {
 // ------------------------------- < Scripting Complete Event > ------------------------------------
 
 export namespace ScriptingCompleteNotification {
-	export const type = new NotificationType<types.ScriptingCompleteParams, void>('scripting/scriptComplete');
+	export const type = new NotificationType<azdata.ScriptingCompleteResult, void>('scripting/scriptComplete');
 }
 
 
@@ -586,38 +571,38 @@ export namespace EditSubsetRequest {
 // ------------------------------- < Object Explorer Events > ------------------------------------
 
 export namespace ObjectExplorerCreateSessionRequest {
-	export const type = new RequestType<azdata.ConnectionInfo, types.CreateSessionResponse, void, void>('objectexplorer/createsession');
+	export const type = new RequestType<azdata.ConnectionInfo, azdata.ObjectExplorerSessionResponse, void, void>('objectexplorer/createsession');
 }
 
 export namespace ObjectExplorerExpandRequest {
-	export const type = new RequestType<types.ExpandParams, boolean, void, void>('objectexplorer/expand');
+	export const type = new RequestType<azdata.ExpandNodeInfo, boolean, void, void>('objectexplorer/expand');
 }
 
 export namespace ObjectExplorerRefreshRequest {
-	export const type = new RequestType<types.ExpandParams, boolean, void, void>('objectexplorer/refresh');
+	export const type = new RequestType<azdata.ExpandNodeInfo, boolean, void, void>('objectexplorer/refresh');
 }
 
 export namespace ObjectExplorerCloseSessionRequest {
-	export const type = new RequestType<types.CloseSessionParams, types.CloseSessionResponse, void, void>('objectexplorer/closesession');
+	export const type = new RequestType<azdata.ObjectExplorerCloseSessionInfo, azdata.ObjectExplorerCloseSessionResponse, void, void>('objectexplorer/closesession');
 }
 
 export namespace ObjectExplorerFindNodesRequest {
-	export const type = new RequestType<types.FindNodesParams, types.FindNodesResponse, void, void>('objectexplorer/findnodes');
+	export const type = new RequestType<azdata.FindNodesInfo, azdata.ObjectExplorerFindNodesResponse, void, void>('objectexplorer/findnodes');
 }
 
 // ------------------------------- < Object Explorer Events > ------------------------------------
 
 
 export namespace ObjectExplorerCreateSessionCompleteNotification {
-	export const type = new NotificationType<types.SessionCreatedParameters, void>('objectexplorer/sessioncreated');
+	export const type = new NotificationType<azdata.ObjectExplorerSession, void>('objectexplorer/sessioncreated');
 }
 
 export namespace ObjectExplorerSessionDisconnectedNotification {
-	export const type = new NotificationType<types.SessionDisconnectedParameters, void>('objectexplorer/sessiondisconnected');
+	export const type = new NotificationType<azdata.ObjectExplorerSession, void>('objectexplorer/sessiondisconnected');
 }
 
 export namespace ObjectExplorerExpandCompleteNotification {
-	export const type = new NotificationType<types.ExpandResponse, void>('objectexplorer/expandCompleted');
+	export const type = new NotificationType<azdata.ObjectExplorerExpandInfo, void>('objectexplorer/expandCompleted');
 }
 
 // ------------------------------- < Task Service Events > ------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,96 +1,5 @@
 import * as azdata from 'azdata';
 
-/**
- * Contains success information, a sessionId to be used when requesting
- * expansion of nodes, and a root node to display for this area
- */
-export interface CreateSessionResponse {
-	/**
-	 * Unique Id to use when sending any requests for objects in the tree
-	 * under the node
-	 */
-	sessionId: string;
-}
-
-/**
- * Information returned from a createSessionRequest. Contains success information, a sessionId to be used
- * when requesting expansion of nodes, and a root node to display for this area
- */
-export interface SessionCreatedParameters {
-	/**
-	 * Whether the session was created successfully.
-	 */
-	success: boolean;
-	/**
-	 * The ID of the session.
-	 */
-	sessionId: string;
-	/**
-	 * The root node for the session, if it was created successfully.
-	 */
-	rootNode: NodeInfo;
-	/**
-	 * Error message for the failure, if the session was not created successfully.
-	 */
-	errorMessage?: string | undefined;
-	/**
-	 * Error number for the failure, if the session was not created successfully.
-	 */
-	errorNumber?: number | undefined;
-}
-
-export interface SessionDisconnectedParameters {
-	success: boolean;
-	sessionId: string;
-	rootNode: NodeInfo;
-	errorMessage: string;
-}
-
-export interface ExpandResponse {
-	nodePath: string;
-	sessionId: string;
-	nodes: NodeInfo[];
-	errorMessage: string;
-}
-
-export interface NodeInfo {
-	nodePath: string;
-	nodeType: string;
-	nodeSubType: string;
-	nodeStatus: string;
-	label: string;
-	isLeaf: boolean;
-	metadata: azdata.ObjectMetadata;
-	errorMessage: string;
-}
-
-export interface ExpandParams {
-	sessionId: string;
-	nodePath: string;
-}
-
-export interface CloseSessionParams {
-	sessionId: string;
-}
-
-export interface CloseSessionResponse {
-	success: boolean;
-	sessionId: string;
-}
-
-export interface FindNodesParams {
-	sessionId: string;
-	type: string;
-	schema: string;
-	name: string;
-	database: string;
-	parentObjectNames: string[];
-}
-
-export interface FindNodesResponse {
-	nodes: NodeInfo[];
-}
-
 export interface CategoryValue {
 	displayName: string;
 
@@ -119,36 +28,6 @@ export interface ServiceOption {
 	isArray: boolean;
 }
 
-export interface ConnectionOption {
-	name: string;
-
-	displayName: string;
-
-	description: string;
-
-	groupName: string;
-
-	valueType: string;
-
-	defaultValue: string;
-
-	objectType: string;
-
-	categoryValues: CategoryValue[];
-
-	specialValueType: string;
-
-	isIdentity: boolean;
-
-	isRequired: boolean;
-
-	isArray: boolean;
-}
-
-export interface ConnectionProviderOptions {
-	options: ConnectionOption[];
-}
-
 export interface AdminServicesProviderOptions {
 	databaseInfoOptions: ServiceOption[];
 
@@ -164,76 +43,6 @@ export interface FeatureMetadataProvider {
 }
 
 /**
- * Summary that identifies a unique database connection.
- */
-export class ConnectionSummary {
-	/**
-	 * server name
-	 */
-	public serverName: string;
-
-	/**
-	 * database name
-	 */
-	public databaseName: string;
-
-	/**
-	 * user name
-	 */
-	public userName: string;
-}
-
-/**
- * Connection response format.
- */
-export class ConnectionCompleteParams {
-	/**
-	 * URI identifying the owner of the connection
-	 */
-	public ownerUri: string;
-
-	/**
-	 * Connection id returned from service host, if the connection was successful.
-	 */
-	public connectionId?: string | undefined;
-
-	/**
-	 * Additional optional detailed error messages from the engine or service host, if an error occurred.
-	 */
-	public messages?: string | undefined;
-
-	/**
-	 * Error message returned from the engine or service host, if an error occurred.
-	 */
-	public errorMessage?: string | undefined;
-
-	/**
-	 * Error number returned from the engine or server host, if an error occurred.
-	 */
-	public errorNumber?: number | undefined;
-
-	/**
-	 * Information about the connected server, if the connection was successful.
-	 */
-	public serverInfo?: ServerInfo | undefined;
-
-	/**
-	 * Information about the actual connection established, if the connection was successful.
-	 */
-	public connectionSummary?: ConnectionSummary | undefined;
-
-	/**
-	 * Whether the server version is supported by the provider. Default is to assume true.
-	 */
-	public isSupportedVersion?: boolean | undefined;
-
-	/**
-	 * Additional optional message with details about why the version isn't supported.
-	 */
-	public unsupportedVersionMessage?: string | undefined;
-}
-
-/**
  * Update event parameters
  */
 export class IntelliSenseReadyParams {
@@ -241,65 +50,6 @@ export class IntelliSenseReadyParams {
 	 * URI identifying the text document
 	 */
 	public ownerUri: string;
-}
-
-/**
- * Information about a SQL Server instance.
- */
-export class ServerInfo {
-	/**
-	 * The major version of the SQL Server instance.
-	 */
-	public serverMajorVersion: number;
-
-	/**
-	 * The minor version of the SQL Server instance.
-	 */
-	public serverMinorVersion: number;
-
-	/**
-	 * The build of the SQL Server instance.
-	 */
-	public serverReleaseVersion: number;
-
-	/**
-	 * The ID of the engine edition of the SQL Server instance.
-	 */
-	public engineEditionId: number;
-
-	/**
-	 * String containing the full server version text.
-	 */
-	public serverVersion: string;
-
-	/**
-	 * String describing the product level of the server.
-	 */
-	public serverLevel: string;
-
-	/**
-	 * The edition of the SQL Server instance.
-	 */
-	public serverEdition: string;
-
-	/**
-	 * Whether the SQL Server instance is running in the cloud (Azure) or not.
-	 */
-	public isCloud: boolean;
-
-	/**
-	 * The version of Azure that the SQL Server instance is running on, if applicable.
-	 */
-	public azureVersion: number;
-
-	/**
-	 * The Operating System version string of the machine running the SQL Server instance.
-	 */
-	public osVersion: string;
-	/**
-	 * options for all new server properties.
-	 */
-	public options: { [key: string]: any };
 }
 
 export class CapabiltiesDiscoveryResult {
@@ -487,74 +237,6 @@ export interface RestorePlanDetailInfo {
 }
 
 // Query Execution types
-export interface ResultSetSummary {
-	id: number;
-	batchId: number;
-	rowCount: number;
-	columnInfo: IDbColumn[];
-}
-
-export interface BatchSummary {
-	hasError: boolean;
-	id: number;
-	selection: azdata.ISelectionData;
-	resultSetSummaries: ResultSetSummary[];
-	executionElapsed: string;
-	executionEnd: string;
-	executionStart: string;
-}
-
-export interface IDbColumn {
-	allowDBNull?: boolean;
-	baseCatalogName: string;
-	baseColumnName: string;
-	baseSchemaName: string;
-	baseServerName: string;
-	baseTableName: string;
-	columnName: string;
-	columnOrdinal?: number;
-	columnSize?: number;
-	isAliased?: boolean;
-	isAutoIncrement?: boolean;
-	isExpression?: boolean;
-	isHidden?: boolean;
-	isIdentity?: boolean;
-	isKey?: boolean;
-	isBytes?: boolean;
-	isChars?: boolean;
-	isSqlVariant?: boolean;
-	isUdt?: boolean;
-	dataType: string;
-	isXml?: boolean;
-	isJson?: boolean;
-	isLong?: boolean;
-	isReadOnly?: boolean;
-	isUnique?: boolean;
-	numericPrecision?: number;
-	numericScale?: number;
-	udtAssemblyQualifiedName: string;
-	dataTypeName: string;
-}
-
-export interface IGridResultSet {
-	columns: IDbColumn[];
-	rowsUri: string;
-	numberOfRows: number;
-}
-
-export interface IResultMessage {
-	batchId?: number;
-	isError: boolean;
-	time: string;
-	message: string;
-}
-
-export interface EditRow {
-	cells: azdata.DbCellValue[];
-	id: number;
-	isDirty: boolean;
-	state: azdata.EditRowState;
-}
 
 export interface ExecutionPlanOptions {
 	includeEstimatedExecutionPlanXml?: boolean;
@@ -858,33 +540,6 @@ export interface ScriptingParams {
 	 * Operation associated with the script request
 	 */
 	operation: azdata.ScriptOperation;
-}
-
-export interface ScriptingCompleteParams {
-	/**
-	 * The error details for an error that occurred during the scripting operation.
-	 */
-	errorDetails: string;
-
-	/**
-	 * The error message for an error that occurred during the scripting operation.
-	 */
-	errorMessage: string;
-
-	/**
-	 * A value to indicate an error occurred during the scripting operation.
-	 */
-	hasError: boolean;
-
-	/**
-	 * A value to indicate the scripting operation was canceled.
-	 */
-	canceled: boolean;
-
-	/**
-	 * A value to indicate the scripting operation successfully completed.
-	 */
-	success: boolean;
 }
 
 export class TableMetadata {

--- a/tslint.json
+++ b/tslint.json
@@ -16,10 +16,6 @@
         "forin": true,
         "jsdoc-format": true,
         "label-position": true,
-        "max-line-length": [
-            true,
-            160
-        ],
         "member-access": false,
         "member-ordering": [
             false,


### PR DESCRIPTION
Noticed this while investigating something else - but we currently have a large amount of "duplicated" types in here. These are types which are already defined in azdata (usually due to them being exposed as provider callbacks).

There isn't any reason I can think of to have these extra ones here - they just add extra overhead to remember to update (and often times that step is missed). And the way that this library uses them is just as types, the original objects passed in are always going to be their azdata counterparts. 

So I went through and removed a bunch that I saw. It's likely I missed a couple, but this makes it a lot cleaner and then we can just be better in the future about keeping an eye on what types are used/updated here and remove others we see as being unnecessary down the line. 

I'm not planning on doing a new release for these since this stuff should all have no change on the existing behavior. 