### PR TITLE
Fix onConnectionChanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,7 +289,15 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 		};
 
 		let registerOnConnectionChanged = (handler: (changedConnInfo: azdata.ChangedConnectionInfo) => any): void => {
-			client.onNotification(protocol.ConnectionChangedNotification.type, handler);
+			// NOTE: The parameter types here are currently different than what's defined in ADS - that uses "connectionUri" while
+			// this uses "ownerUri". So we need to translate that here so that the object ADS gets is actually correct.
+			// See https://github.com/microsoft/sqlops-dataprotocolclient/issues/88 for details
+			client.onNotification(protocol.ConnectionChangedNotification.type, (params: protocol.ConnectionChangedParams) => {
+				handler({
+					connectionUri: params.ownerUri,
+					connection: params.connection
+				});
+			});
 		};
 
 		azdata.dataprotocol.onDidChangeLanguageFlavor((params) => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -128,11 +128,29 @@ export namespace ConnectionCompleteNotification {
 
 // ------------------------------- < Connection Changed Event > -------------------------------------
 
+// NOTE: The parameter types here are currently different than what's defined in ADS - that uses "connectionUri" while
+// this uses "ownerUri". See https://github.com/microsoft/sqlops-dataprotocolclient/issues/88 for details
+
+/**
+ * Parameters for the ConnectionChanged notification.
+ */
+export class ConnectionChangedParams {
+	/**
+	 * Owner URI of the connection that changed.
+	 */
+	public ownerUri: string;
+
+	/**
+	 * Summary of details containing any connection changes.
+	 */
+	public connection: azdata.ConnectionSummary
+}
+
 /**
  * Connection changed event callback declaration.
  */
 export namespace ConnectionChangedNotification {
-	export const type = new NotificationType<azdata.ChangedConnectionInfo, void>('connection/connectionchanged');
+	export const type = new NotificationType<ConnectionChangedParams, void>('connection/connectionchanged');
 }
 
 // ------------------------------- < Password Change for Connection Event > -------------------------------------

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -143,7 +143,7 @@ export class ConnectionChangedParams {
 	/**
 	 * Summary of details containing any connection changes.
 	 */
-	public connection: azdata.ConnectionSummary
+	public connection: azdata.ConnectionSummary;
 }
 
 /**


### PR DESCRIPTION
This was broken in https://github.com/microsoft/sqlops-dataprotocolclient/pull/85 - there I changed the types being used for the parameter without realizing that what we have defined in azdata.d.ts and what we expect here were different. So I'm just reverting that change for now.

I've opened up https://github.com/microsoft/sqlops-dataprotocolclient/issues/88 for follow up investigation though since that seems like a bug - providers aren't normally going to using these types so having them differ could easily cause issues and is just confusing.

For https://github.com/microsoft/azuredatastudio/issues/23565#