### PR TITLE
Use EventEmitters for registering notification handlers

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataprotocol-client",
-  "version": "1.3.8",
+  "version": "2.0.0",
   "description": "Client data protocol implementation for Azure Data Studio",
   "main": "lib/main",
   "typings": "lib/main",

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,7 @@ export abstract class SqlOpsFeature<T> implements DynamicFeature<T> {
 		let provider = this._providers.get(id);
 		if (provider) {
 			provider.dispose();
+			// TODO Should remove it from list
 		}
 	}
 
@@ -95,7 +96,7 @@ export abstract class SqlOpsFeature<T> implements DynamicFeature<T> {
 	 * Registers an EventEmitter for the specified notification, which will fire an event whenever that notification is received.
 	 */
 	protected registerNotificationEmitter<P, RO>(notificationType: NotificationType<P, RO>): vscode.EventEmitter<P> {
-		var eventEmitter = new vscode.EventEmitter<P>();
+		const eventEmitter = new vscode.EventEmitter<P>();
 		this._disposables.push(eventEmitter);
 		this._client.onNotification(notificationType, params => {
 			eventEmitter.fire(params);
@@ -295,17 +296,17 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 			return Promise.resolve();
 		};
 
-		var onConnectionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ConnectionCompleteNotification.type);
+		const onConnectionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ConnectionCompleteNotification.type);
 		let registerOnConnectionComplete = (handler: (connSummary: azdata.ConnectionInfoSummary) => any): vscode.Disposable => {
 			return onConnectionCompleteEventEmitter.event(handler);
 		};
 
-		var onIntelliSenseReadyEventEmitter = this.registerNotificationEmitter(protocol.IntelliSenseReadyNotification.type);
+		const onIntelliSenseReadyEventEmitter = this.registerNotificationEmitter(protocol.IntelliSenseReadyNotification.type);
 		let registerOnIntelliSenseCacheComplete = (handler: (connectionUri: string) => any): vscode.Disposable => {
 			return onIntelliSenseReadyEventEmitter.event(params => handler(params.ownerUri));
 		};
 
-		var onConnectionChangedEventEmitter = this.registerNotificationEmitter(protocol.ConnectionChangedNotification.type);
+		const onConnectionChangedEventEmitter = this.registerNotificationEmitter(protocol.ConnectionChangedNotification.type);
 		let registerOnConnectionChanged = (handler: (changedConnInfo: azdata.ChangedConnectionInfo) => any): vscode.Disposable => {
 			// NOTE: The parameter types here are currently different than what's defined in ADS - that uses "connectionUri" while
 			// this uses "ownerUri". So we need to translate that here so that the object ADS gets is actually correct.
@@ -495,32 +496,32 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 			return Promise.resolve();
 		};
 
-		var onQueryCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteCompleteNotification.type);
+		const onQueryCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteCompleteNotification.type);
 		let registerOnQueryComplete = (handler: (result: azdata.QueryExecuteCompleteNotificationResult) => any): vscode.Disposable => {
 			return onQueryCompleteEventEmitter.event(handler);
 		};
 
-		var onQueryExecuteBatchStartEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchStartNotification.type);
+		const onQueryExecuteBatchStartEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchStartNotification.type);
 		let registerOnBatchStart = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): vscode.Disposable => {
 			return onQueryExecuteBatchStartEventEmitter.event(handler);
 		};
 
-		var onQueryExecuteBatchCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchCompleteNotification.type);
+		const onQueryExecuteBatchCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchCompleteNotification.type);
 		let registerOnBatchComplete = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): vscode.Disposable => {
 			return onQueryExecuteBatchCompleteEventEmitter.event(handler);
 		};
 
-		var onQueryExecuteResultSetAvailableEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetAvailableNotification.type);
+		const onQueryExecuteResultSetAvailableEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetAvailableNotification.type);
 		let registerOnResultSetAvailable = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): vscode.Disposable => {
 			return onQueryExecuteResultSetAvailableEventEmitter.event(handler);
 		};
 
-		var onQueryExecuteResultSetUpdatedEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetUpdatedNotification.type);
+		const onQueryExecuteResultSetUpdatedEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetUpdatedNotification.type);
 		let registerOnResultSetUpdated = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): vscode.Disposable => {
 			return onQueryExecuteResultSetUpdatedEventEmitter.event(handler);
 		};
 
-		var onQueryExecuteMessageEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteMessageNotification.type);
+		const onQueryExecuteMessageEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteMessageNotification.type);
 		let registerOnMessage = (handler: (message: azdata.QueryExecuteMessageParams) => any): vscode.Disposable => {
 			return onQueryExecuteMessageEventEmitter.event(handler);
 		};
@@ -703,7 +704,7 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 		};
 
 		// Edit Data Event Handlers
-		var onEditSessionReadyEventEmitter = this.registerNotificationEmitter(protocol.EditSessionReadyNotification.type);
+		const onEditSessionReadyEventEmitter = this.registerNotificationEmitter(protocol.EditSessionReadyNotification.type);
 		let registerOnEditSessionReady = (handler: (ownerUri: string, success: boolean, message: string) => any): vscode.Disposable => {
 			return onEditSessionReadyEventEmitter.event(params => handler(params.ownerUri, params.success, params.message));
 		};
@@ -1117,17 +1118,17 @@ export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		var onObjectExplorerCreateSessionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerCreateSessionCompleteNotification.type);
+		const onObjectExplorerCreateSessionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerCreateSessionCompleteNotification.type);
 		let registerOnSessionCreated = (handler: (response: azdata.ObjectExplorerSession) => any): vscode.Disposable => {
 			return onObjectExplorerCreateSessionCompleteEventEmitter.event(handler);
 		};
 
-		var onObjectExplorerSessionDisconnectedEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerSessionDisconnectedNotification.type);
+		const onObjectExplorerSessionDisconnectedEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerSessionDisconnectedNotification.type);
 		let registerOnSessionDisconnected = (handler: (response: azdata.ObjectExplorerSession) => any): vscode.Disposable => {
 			return onObjectExplorerSessionDisconnectedEventEmitter.event(handler);
 		};
 
-		var onObjectExplorerExpandCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerExpandCompleteNotification.type);
+		const onObjectExplorerExpandCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerExpandCompleteNotification.type);
 		let registerOnExpandCompleted = (handler: (response: azdata.ObjectExplorerExpandInfo) => any): vscode.Disposable => {
 			return onObjectExplorerExpandCompleteEventEmitter.event(handler);
 		};
@@ -1185,7 +1186,7 @@ export class ScriptingFeature extends SqlOpsFeature<undefined> {
 				);
 		};
 
-		var onScriptingCompleteEventEmitter = this.registerNotificationEmitter(protocol.ScriptingCompleteNotification.type);
+		const onScriptingCompleteEventEmitter = this.registerNotificationEmitter(protocol.ScriptingCompleteNotification.type);
 		let registerOnScriptingComplete = (handler: (scriptingCompleteResult: azdata.ScriptingCompleteResult) => any): vscode.Disposable => {
 			return onScriptingCompleteEventEmitter.event(handler);
 		};
@@ -1245,12 +1246,12 @@ export class TaskServicesFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		var onTaskCreatedEventEmitter = this.registerNotificationEmitter(protocol.TaskCreatedNotification.type);
+		const onTaskCreatedEventEmitter = this.registerNotificationEmitter(protocol.TaskCreatedNotification.type);
 		let registerOnTaskCreated = (handler: (response: azdata.TaskInfo) => any): vscode.Disposable => {
 			return onTaskCreatedEventEmitter.event(handler);
 		};
 
-		var onTaskStatusChangedEventEmitter = this.registerNotificationEmitter(protocol.TaskStatusChangedNotification.type);
+		const onTaskStatusChangedEventEmitter = this.registerNotificationEmitter(protocol.TaskStatusChangedNotification.type);
 		let registerOnTaskStatusChanged = (handler: (response: azdata.TaskProgressInfo) => any): vscode.Disposable => {
 			return onTaskStatusChangedEventEmitter.event(handler);
 		};
@@ -1305,7 +1306,7 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		var onFileBrowserOpenedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserOpenedNotification.type);
+		const onFileBrowserOpenedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserOpenedNotification.type);
 		let registerOnFileBrowserOpened = (handler: (response: azdata.FileBrowserOpenedParams) => any): vscode.Disposable => {
 			return onFileBrowserOpenedEventEmitter.event(handler);
 		};
@@ -1321,7 +1322,7 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		var onFileBrowserExpandedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserExpandedNotification.type);
+		const onFileBrowserExpandedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserExpandedNotification.type);
 		let registerOnFolderNodeExpanded = (handler: (response: azdata.FileBrowserExpandedParams) => any): vscode.Disposable => {
 			return onFileBrowserExpandedEventEmitter.event(handler);
 		};
@@ -1337,7 +1338,7 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		var onFileBrowserValidatedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserValidatedNotification.type);
+		const onFileBrowserValidatedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserValidatedNotification.type);
 		let registerOnFilePathsValidated = (handler: (response: azdata.FileBrowserValidatedParams) => any): vscode.Disposable => {
 			return onFileBrowserValidatedEventEmitter.event(handler);
 		};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,13 @@
 import {
 	LanguageClient, ServerOptions, LanguageClientOptions as VSLanguageClientOptions, DynamicFeature, ServerCapabilities, RegistrationData,
-	RPCMessageType, Disposable, RequestType
+	RPCMessageType, Disposable, RequestType, NotificationType
 } from 'vscode-languageclient';
 
 import * as is from 'vscode-languageclient/lib/utils/is';
 import * as UUID from 'vscode-languageclient/lib/utils/uuid';
 
 import * as azdata from 'azdata';
+import * as vscode from 'vscode';
 
 import { c2p, Ic2p } from './codeConverter';
 
@@ -36,6 +37,7 @@ export interface ClientOptions extends VSLanguageClientOptions {
 export abstract class SqlOpsFeature<T> implements DynamicFeature<T> {
 
 	protected _providers: Map<string, Disposable> = new Map<string, Disposable>();
+	protected _disposables: Disposable[] = [];
 
 	constructor(protected _client: SqlOpsDataClient, private _message: RPCMessageType | RPCMessageType[]) {
 	}
@@ -84,6 +86,21 @@ export abstract class SqlOpsFeature<T> implements DynamicFeature<T> {
 		this._providers.forEach((value) => {
 			value.dispose();
 		});
+		this._disposables.forEach(d => d.dispose());
+		this._providers.clear();
+		this._disposables = [];
+	}
+
+	/**
+	 * Registers an EventEmitter for the specified notification, which will fire an event whenever that notification is received.
+	 */
+	protected registerNotificationEmitter<P, RO>(notificationType: NotificationType<P, RO>): vscode.EventEmitter<P> {
+		var eventEmitter = new vscode.EventEmitter<P>();
+		this._disposables.push(eventEmitter);
+		this._client.onNotification(notificationType, params => {
+			eventEmitter.fire(params);
+		});
+		return eventEmitter;
 	}
 }
 
@@ -278,26 +295,25 @@ export class ConnectionFeature extends SqlOpsFeature<undefined> {
 			return Promise.resolve();
 		};
 
-		let registerOnConnectionComplete = (handler: (connSummary: azdata.ConnectionInfoSummary) => any): void => {
-			client.onNotification(protocol.ConnectionCompleteNotification.type, handler);
+		var onConnectionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ConnectionCompleteNotification.type);
+		let registerOnConnectionComplete = (handler: (connSummary: azdata.ConnectionInfoSummary) => any): vscode.Disposable => {
+			return onConnectionCompleteEventEmitter.event(handler);
 		};
 
-		let registerOnIntelliSenseCacheComplete = (handler: (connectionUri: string) => any): void => {
-			client.onNotification(protocol.IntelliSenseReadyNotification.type, (params: types.IntelliSenseReadyParams) => {
-				handler(params.ownerUri);
-			});
+		var onIntelliSenseReadyEventEmitter = this.registerNotificationEmitter(protocol.IntelliSenseReadyNotification.type);
+		let registerOnIntelliSenseCacheComplete = (handler: (connectionUri: string) => any): vscode.Disposable => {
+			return onIntelliSenseReadyEventEmitter.event(params => handler(params.ownerUri));
 		};
 
-		let registerOnConnectionChanged = (handler: (changedConnInfo: azdata.ChangedConnectionInfo) => any): void => {
+		var onConnectionChangedEventEmitter = this.registerNotificationEmitter(protocol.ConnectionChangedNotification.type);
+		let registerOnConnectionChanged = (handler: (changedConnInfo: azdata.ChangedConnectionInfo) => any): vscode.Disposable => {
 			// NOTE: The parameter types here are currently different than what's defined in ADS - that uses "connectionUri" while
 			// this uses "ownerUri". So we need to translate that here so that the object ADS gets is actually correct.
 			// See https://github.com/microsoft/sqlops-dataprotocolclient/issues/88 for details
-			client.onNotification(protocol.ConnectionChangedNotification.type, (params: protocol.ConnectionChangedParams) => {
-				handler({
-					connectionUri: params.ownerUri,
-					connection: params.connection
-				});
-			});
+			return onConnectionChangedEventEmitter.event(params => handler({
+				connectionUri: params.ownerUri,
+				connection: params.connection
+			}));
 		};
 
 		azdata.dataprotocol.onDidChangeLanguageFlavor((params) => {
@@ -479,28 +495,34 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 			return Promise.resolve();
 		};
 
-		let registerOnQueryComplete = (handler: (result: azdata.QueryExecuteCompleteNotificationResult) => any): void => {
-			client.onNotification(protocol.QueryExecuteCompleteNotification.type, handler);
+		var onQueryCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteCompleteNotification.type);
+		let registerOnQueryComplete = (handler: (result: azdata.QueryExecuteCompleteNotificationResult) => any): vscode.Disposable => {
+			return onQueryCompleteEventEmitter.event(handler);
 		};
 
-		let registerOnBatchStart = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): void => {
-			client.onNotification(protocol.QueryExecuteBatchStartNotification.type, handler);
+		var onQueryExecuteBatchStartEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchStartNotification.type);
+		let registerOnBatchStart = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): vscode.Disposable => {
+			return onQueryExecuteBatchStartEventEmitter.event(handler);
 		};
 
-		let registerOnBatchComplete = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): void => {
-			client.onNotification(protocol.QueryExecuteBatchCompleteNotification.type, handler);
+		var onQueryExecuteBatchCompleteEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteBatchCompleteNotification.type);
+		let registerOnBatchComplete = (handler: (batchInfo: azdata.QueryExecuteBatchNotificationParams) => any): vscode.Disposable => {
+			return onQueryExecuteBatchCompleteEventEmitter.event(handler);
 		};
 
-		let registerOnResultSetAvailable = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): void => {
-			client.onNotification(protocol.QueryExecuteResultSetAvailableNotification.type, handler);
+		var onQueryExecuteResultSetAvailableEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetAvailableNotification.type);
+		let registerOnResultSetAvailable = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): vscode.Disposable => {
+			return onQueryExecuteResultSetAvailableEventEmitter.event(handler);
 		};
 
-		let registerOnResultSetUpdated = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): void => {
-			client.onNotification(protocol.QueryExecuteResultSetUpdatedNotification.type, handler);
+		var onQueryExecuteResultSetUpdatedEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteResultSetUpdatedNotification.type);
+		let registerOnResultSetUpdated = (handler: (resultSetInfo: azdata.QueryExecuteResultSetNotificationParams) => any): vscode.Disposable => {
+			return onQueryExecuteResultSetUpdatedEventEmitter.event(handler);
 		};
 
-		let registerOnMessage = (handler: (message: azdata.QueryExecuteMessageParams) => any): void => {
-			client.onNotification(protocol.QueryExecuteMessageNotification.type, handler);
+		var onQueryExecuteMessageEventEmitter = this.registerNotificationEmitter(protocol.QueryExecuteMessageNotification.type);
+		let registerOnMessage = (handler: (message: azdata.QueryExecuteMessageParams) => any): vscode.Disposable => {
+			return onQueryExecuteMessageEventEmitter.event(handler);
 		};
 
 		let saveResults = (requestParams: azdata.SaveResultsRequestParams): Thenable<azdata.SaveResultRequestResult> => {
@@ -681,10 +703,9 @@ export class QueryFeature extends SqlOpsFeature<undefined> {
 		};
 
 		// Edit Data Event Handlers
-		let registerOnEditSessionReady = (handler: (ownerUri: string, success: boolean, message: string) => any): void => {
-			client.onNotification(protocol.EditSessionReadyNotification.type, (params: azdata.EditSessionReadyParams) => {
-				handler(params.ownerUri, params.success, params.message);
-			});
+		var onEditSessionReadyEventEmitter = this.registerNotificationEmitter(protocol.EditSessionReadyNotification.type);
+		let registerOnEditSessionReady = (handler: (ownerUri: string, success: boolean, message: string) => any): vscode.Disposable => {
+			return onEditSessionReadyEventEmitter.event(params => handler(params.ownerUri, params.success, params.message));
 		};
 
 		return azdata.dataprotocol.registerQueryProvider({
@@ -1096,16 +1117,19 @@ export class ObjectExplorerFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let registerOnSessionCreated = (handler: (response: azdata.ObjectExplorerSession) => any): void => {
-			client.onNotification(protocol.ObjectExplorerCreateSessionCompleteNotification.type, handler);
+		var onObjectExplorerCreateSessionCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerCreateSessionCompleteNotification.type);
+		let registerOnSessionCreated = (handler: (response: azdata.ObjectExplorerSession) => any): vscode.Disposable => {
+			return onObjectExplorerCreateSessionCompleteEventEmitter.event(handler);
 		};
 
-		let registerOnSessionDisconnected = (handler: (response: azdata.ObjectExplorerSession) => any): void => {
-			client.onNotification(protocol.ObjectExplorerSessionDisconnectedNotification.type, handler);
+		var onObjectExplorerSessionDisconnectedEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerSessionDisconnectedNotification.type);
+		let registerOnSessionDisconnected = (handler: (response: azdata.ObjectExplorerSession) => any): vscode.Disposable => {
+			return onObjectExplorerSessionDisconnectedEventEmitter.event(handler);
 		};
 
-		let registerOnExpandCompleted = (handler: (response: azdata.ObjectExplorerExpandInfo) => any): void => {
-			client.onNotification(protocol.ObjectExplorerExpandCompleteNotification.type, handler);
+		var onObjectExplorerExpandCompleteEventEmitter = this.registerNotificationEmitter(protocol.ObjectExplorerExpandCompleteNotification.type);
+		let registerOnExpandCompleted = (handler: (response: azdata.ObjectExplorerExpandInfo) => any): vscode.Disposable => {
+			return onObjectExplorerExpandCompleteEventEmitter.event(handler);
 		};
 
 		return azdata.dataprotocol.registerObjectExplorerProvider({
@@ -1161,8 +1185,9 @@ export class ScriptingFeature extends SqlOpsFeature<undefined> {
 				);
 		};
 
-		let registerOnScriptingComplete = (handler: (scriptingCompleteResult: azdata.ScriptingCompleteResult) => any): void => {
-			client.onNotification(protocol.ScriptingCompleteNotification.type, handler);
+		var onScriptingCompleteEventEmitter = this.registerNotificationEmitter(protocol.ScriptingCompleteNotification.type);
+		let registerOnScriptingComplete = (handler: (scriptingCompleteResult: azdata.ScriptingCompleteResult) => any): vscode.Disposable => {
+			return onScriptingCompleteEventEmitter.event(handler);
 		};
 
 		return azdata.dataprotocol.registerScriptingProvider({
@@ -1220,12 +1245,14 @@ export class TaskServicesFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let registerOnTaskCreated = (handler: (response: azdata.TaskInfo) => any): void => {
-			client.onNotification(protocol.TaskCreatedNotification.type, handler);
+		var onTaskCreatedEventEmitter = this.registerNotificationEmitter(protocol.TaskCreatedNotification.type);
+		let registerOnTaskCreated = (handler: (response: azdata.TaskInfo) => any): vscode.Disposable => {
+			return onTaskCreatedEventEmitter.event(handler);
 		};
 
-		let registerOnTaskStatusChanged = (handler: (response: azdata.TaskProgressInfo) => any): void => {
-			client.onNotification(protocol.TaskStatusChangedNotification.type, handler);
+		var onTaskStatusChangedEventEmitter = this.registerNotificationEmitter(protocol.TaskStatusChangedNotification.type);
+		let registerOnTaskStatusChanged = (handler: (response: azdata.TaskProgressInfo) => any): vscode.Disposable => {
+			return onTaskStatusChangedEventEmitter.event(handler);
 		};
 
 		return azdata.dataprotocol.registerTaskServicesProvider({
@@ -1278,8 +1305,9 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let registerOnFileBrowserOpened = (handler: (response: azdata.FileBrowserOpenedParams) => any): void => {
-			client.onNotification(protocol.FileBrowserOpenedNotification.type, handler);
+		var onFileBrowserOpenedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserOpenedNotification.type);
+		let registerOnFileBrowserOpened = (handler: (response: azdata.FileBrowserOpenedParams) => any): vscode.Disposable => {
+			return onFileBrowserOpenedEventEmitter.event(handler);
 		};
 
 		let expandFolderNode = (ownerUri: string, expandPath: string): Thenable<boolean> => {
@@ -1293,8 +1321,9 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let registerOnFolderNodeExpanded = (handler: (response: azdata.FileBrowserExpandedParams) => any): void => {
-			client.onNotification(protocol.FileBrowserExpandedNotification.type, handler);
+		var onFileBrowserExpandedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserExpandedNotification.type);
+		let registerOnFolderNodeExpanded = (handler: (response: azdata.FileBrowserExpandedParams) => any): vscode.Disposable => {
+			return onFileBrowserExpandedEventEmitter.event(handler);
 		};
 
 		let validateFilePaths = (ownerUri: string, serviceType: string, selectedFiles: string[]): Thenable<boolean> => {
@@ -1308,8 +1337,9 @@ export class FileBrowserFeature extends SqlOpsFeature<undefined> {
 			);
 		};
 
-		let registerOnFilePathsValidated = (handler: (response: azdata.FileBrowserValidatedParams) => any): void => {
-			client.onNotification(protocol.FileBrowserValidatedNotification.type, handler);
+		var onFileBrowserValidatedEventEmitter = this.registerNotificationEmitter(protocol.FileBrowserValidatedNotification.type);
+		let registerOnFilePathsValidated = (handler: (response: azdata.FileBrowserValidatedParams) => any): vscode.Disposable => {
+			return onFileBrowserValidatedEventEmitter.event(handler);
 		};
 
 		let closeFileBrowser = (ownerUri: string): Thenable<azdata.FileBrowserCloseResponse> => {


### PR DESCRIPTION
Fixes https://github.com/microsoft/sqlops-dataprotocolclient/issues/62 - which will allow multiple handlers to be registered so extensions can hook into the events themselves without breaking ADS.

https://github.com/microsoft/azuredatastudio/issues/24617 is an example of someone wanting to do that. 

As part of this I will be modifying the azdata API to return the disposable (it was void previously) to allow for disposal of the handlers (such as when an extension is deactivated). This is a "breaking" change, but shouldn't cause any runtimes issues since we weren't returning anything before. 